### PR TITLE
Update to use the latest revision of `mdspan`

### DIFF
--- a/include/experimental/__p1684_bits/basic_mdarray.hpp
+++ b/include/experimental/__p1684_bits/basic_mdarray.hpp
@@ -50,7 +50,7 @@
 #include <experimental/__p0009_bits/macros.hpp>
 #include <experimental/__p0009_bits/layout_right.hpp>
 #include <experimental/__p0009_bits/extents.hpp>
-#include <experimental/__p0009_bits/basic_mdspan.hpp>
+#include <experimental/__p0009_bits/mdspan.hpp>
 
 namespace std {
 namespace experimental {
@@ -71,7 +71,7 @@ struct _basic_mdarray_crtp_helper<
  protected:
   MDSPAN_FORCE_INLINE_FUNCTION Derived& __self() noexcept { return *static_cast<Derived*>(this); }
   MDSPAN_FORCE_INLINE_FUNCTION Derived const& __self() const noexcept { return *static_cast<Derived const*>(this); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr ptrdiff_t __size() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr size_t __size() const noexcept {
     return _MDSPAN_FOLD_TIMES_RIGHT((__self().map_.extents().template __extent<ExtIdxs>()), /* * ... * */ 1);
   }
   template <class ReferenceType, class IndexType, size_t N>
@@ -97,7 +97,7 @@ class basic_mdarray;
 
 template <
   class ElementType,
-  ptrdiff_t... Exts,
+  size_t... Exts,
   class LayoutPolicy,
   class ContainerPolicy
 >
@@ -122,8 +122,8 @@ public:
   using layout_type = LayoutPolicy;
   using mapping_type = typename layout_type::template mapping<extents_type>; // TODO @proposal-bug typo in synopsis
   using value_type = remove_cv_t<element_type>;
-  using index_type = ptrdiff_t;
-  using difference_type = ptrdiff_t;
+  using index_type = size_t;
+  using difference_type = size_t;
   using container_policy_type = ContainerPolicy;
   using container_type = typename container_policy_type::container_type;
   using pointer = typename container_policy_type::pointer; // TODO @proposal-bug this is misspelled in the synopsis
@@ -131,9 +131,9 @@ public:
   using reference = typename container_policy_type::reference;
   using const_reference = typename container_policy_type::const_reference;
   using view_type =
-    basic_mdspan<element_type, extents_type, layout_type, container_policy_type>;
+    mdspan<element_type, extents_type, layout_type, container_policy_type>;
   using const_view_type =
-    basic_mdspan<const element_type, extents_type, layout_type,
+    mdspan<const element_type, extents_type, layout_type,
       __detail::__const_wrapped_accessor_policy<container_policy_type>
     >;
 
@@ -408,7 +408,7 @@ private:
 
 };
 
-template <class T, ptrdiff_t... Exts>
+template <class T, size_t... Exts>
 using mdarray = basic_mdarray<T, std::experimental::extents<Exts...>>;
 
 } // end namespace __mdarray_version_0

--- a/include/experimental/__p1684_bits/const_wrapped_accessor_policy.hpp
+++ b/include/experimental/__p1684_bits/const_wrapped_accessor_policy.hpp
@@ -101,14 +101,14 @@ struct __const_wrapped_accessor_policy {
   { }
 
   MDSPAN_INLINE_FUNCTION
-  constexpr reference access(pointer ptr, ptrdiff_t i) const
+  constexpr reference access(pointer ptr, size_t i) const
   noexcept(noexcept(__underlying_cp.access(ptr, i)))
   {
     return __underlying_cp.access(ptr, i);
   }
 
   MDSPAN_INLINE_FUNCTION
-  constexpr pointer offset(pointer p, ptrdiff_t i) const
+  constexpr pointer offset(pointer p, size_t i) const
   noexcept(noexcept(__underlying_cp.offset(p, i)))
   {
     return __underlying_cp.offset(p, i);

--- a/include/experimental/__p1684_bits/container_policy_basic.hpp
+++ b/include/experimental/__p1684_bits/container_policy_basic.hpp
@@ -77,32 +77,32 @@ public:
   using const_reference = typename container_type::const_reference;
 
   MDSPAN_FORCE_INLINE_FUNCTION
-  static constexpr reference access(container_type& c, ptrdiff_t i)
+  static constexpr reference access(container_type& c, size_t i)
     noexcept(noexcept(c[i]))
   {
     return c[size_t(i)];
   }
   MDSPAN_FORCE_INLINE_FUNCTION
-  static constexpr const_reference access(container_type const& c, ptrdiff_t i)
+  static constexpr const_reference access(container_type const& c, size_t i)
     noexcept(noexcept(c[i]))
   {
     return c[size_t(i)];
   }
   MDSPAN_FORCE_INLINE_FUNCTION
-  static constexpr reference access(pointer c, ptrdiff_t i) noexcept {
+  static constexpr reference access(pointer c, size_t i) noexcept {
     return c[size_t(i)];
   }
   MDSPAN_FORCE_INLINE_FUNCTION
-  static constexpr const_reference access(const_pointer c, ptrdiff_t i) noexcept {
+  static constexpr const_reference access(const_pointer c, size_t i) noexcept {
     return c[size_t(i)];
   }
 
   MDSPAN_INLINE_FUNCTION
-  static constexpr pointer offset(pointer p, ptrdiff_t i) noexcept {
+  static constexpr pointer offset(pointer p, size_t i) noexcept {
     return &p[size_t(i)];
   }
   MDSPAN_INLINE_FUNCTION
-  static constexpr const_pointer offset(const_pointer p, ptrdiff_t i) noexcept {
+  static constexpr const_pointer offset(const_pointer p, size_t i) noexcept {
     return &p[size_t(i)];
   }
 
@@ -197,7 +197,7 @@ namespace __detail {
 //==============================================================================
 // <editor-fold desc="container policy select implementation"> {{{1
 
-template <ptrdiff_t> using __void_ptrdiff_t = void;
+template <size_t> using __void_size_t = void;
 
 // TODO make an alternative to this that works with MSVC?
 template <class Map, class=void>
@@ -207,13 +207,13 @@ struct __has_constexpr_required_span_size
 
 template <class Map>
 struct __has_constexpr_required_span_size<
-  Map, __void_ptrdiff_t<(Map{}.required_span_size(), 0)>
+  Map, __void_size_t<(Map{}.required_span_size(), 0)>
 > : std::true_type
 { static constexpr auto size = Map{}.required_span_size(); };
 
 template <class, class, class> struct __container_policy_select;
 
-template <class T, class LP, ptrdiff_t... Extents>
+template <class T, class LP, size_t... Extents>
 struct __container_policy_select<
   T, LP, std::experimental::extents<Extents...>
 >


### PR DESCRIPTION
* No more `basic_mdspan`.
* `ptrdiff_t`s become `size_t`s.