### PR TITLE
Implemented uses-allocator constructors

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,3 +5,4 @@ function(mdarray_add_example EXENAME)
 endfunction(mdarray_add_example)
 
 add_subdirectory(dot_product)
+add_subdirectory(pmr_usage)

--- a/examples/dot_product/dot_product.cpp
+++ b/examples/dot_product/dot_product.cpp
@@ -61,7 +61,9 @@ int main() {
     auto a = array_2d_dynamic(rows, cols);
     auto b = array_2d_dynamic_left(rows, cols);
     auto c = array_2d_dynamic(std::allocator<int>{});
-    //auto d = array_2d_dynamic( 3, 4, std::allocator<int>());
+    auto d = array_2d_dynamic(std::allocator_arg, std::allocator<int>{}, 3, 4);
+    array_2d_dynamic e{d, std::allocator<int>{}};
+    array_2d_dynamic f{std::move(e), std::allocator<int>{}};
 
     fill_in_order(a);
     fill_in_order(b);

--- a/examples/dot_product/dot_product.cpp
+++ b/examples/dot_product/dot_product.cpp
@@ -61,6 +61,7 @@ int main() {
     auto a = array_2d_dynamic(rows, cols);
     auto b = array_2d_dynamic_left(rows, cols);
     auto c = array_2d_dynamic(std::allocator<int>{});
+    //auto d = array_2d_dynamic( 3, 4, std::allocator<int>());
 
     fill_in_order(a);
     fill_in_order(b);

--- a/examples/dot_product/dot_product.cpp
+++ b/examples/dot_product/dot_product.cpp
@@ -61,7 +61,7 @@ int main() {
     auto a = array_2d_dynamic(rows, cols);
     auto b = array_2d_dynamic_left(rows, cols);
     auto c = array_2d_dynamic(std::allocator<int>{});
-    auto d = array_2d_dynamic(std::allocator_arg, std::allocator<int>{}, 3, 4);
+    auto d = array_2d_dynamic(3, 4, std::allocator<int>{});
     array_2d_dynamic e{d, std::allocator<int>{}};
     array_2d_dynamic f{std::move(e), std::allocator<int>{}};
 

--- a/examples/dot_product/dot_product.cpp
+++ b/examples/dot_product/dot_product.cpp
@@ -60,6 +60,7 @@ int main() {
 
     auto a = array_2d_dynamic(rows, cols);
     auto b = array_2d_dynamic_left(rows, cols);
+    auto c = array_2d_dynamic(std::allocator<int>{});
 
     fill_in_order(a);
     fill_in_order(b);

--- a/examples/pmr_usage/CMakeLists.txt
+++ b/examples/pmr_usage/CMakeLists.txt
@@ -1,0 +1,1 @@
+mdarray_add_example(pmr_usage)

--- a/examples/pmr_usage/pmr_usage.cpp
+++ b/examples/pmr_usage/pmr_usage.cpp
@@ -1,0 +1,74 @@
+#include <experimental/mdarray>
+
+#include <iostream>
+
+#include <vector>
+
+namespace stdex = std::experimental;
+
+#ifdef __cpp_lib_memory_resource
+#include <memory_resource>
+
+
+//For testing, prints allocs and deallocs to cout
+struct ChatterResource : std::pmr::memory_resource{
+
+    ChatterResource() = default;
+
+    ChatterResource(std::pmr::memory_resource* upstream): upstream(upstream){}
+
+    ChatterResource(const ChatterResource&) = delete;
+
+    ChatterResource(ChatterResource&&) = delete;
+
+    ChatterResource& operator=(const ChatterResource&) = delete;
+
+    ChatterResource& operator=(ChatterResource&&) = delete;
+
+    private:
+
+    void* do_allocate( std::size_t bytes, std::size_t alignment ) override{
+
+        std::cout << "Allocation - size: " << bytes << ", alignment: " << alignment << std::endl;
+
+        return upstream->allocate(bytes, alignment);
+        //else return new chunk
+    }
+
+    void do_deallocate( void* p, std::size_t bytes, std::size_t alignment ) override{
+
+        std::cout << "Deallocation - size: " << bytes << ", alignment: " << alignment << std::endl;
+
+        upstream->deallocate(p, bytes, alignment);
+    }
+
+    bool do_is_equal( const std::pmr::memory_resource& other ) const noexcept override{
+        return this == &other;
+    };
+
+    std::pmr::memory_resource* upstream = std::pmr::get_default_resource();
+};
+
+
+int main(){
+
+    using array_2d_pmr_dynamic = stdex::basic_mdarray<int, stdex::extents<stdex::dynamic_extent, stdex::dynamic_extent>, stdex::layout_right, stdex::vector_container_policy<int, std::pmr::polymorphic_allocator<int>>>;
+
+    ChatterResource allocation_logger;
+    constexpr bool test = std::uses_allocator_v<array_2d_pmr_dynamic, std::pmr::polymorphic_allocator<int>>;
+    std::cout << sizeof(array_2d_pmr_dynamic) << std::endl;
+
+    array_2d_pmr_dynamic mdarray{std::allocator_arg, &allocation_logger, 3,3};
+
+    std::pmr::vector<array_2d_pmr_dynamic> top_container{&allocation_logger};
+    top_container.reserve(4);
+
+    top_container.emplace_back(3,3);
+    top_container.emplace_back(mdarray.mapping());
+    top_container.emplace_back(mdarray.mapping(), mdarray.container_policy());
+    top_container.push_back({mdarray});
+
+}
+
+
+#endif

--- a/examples/pmr_usage/pmr_usage.cpp
+++ b/examples/pmr_usage/pmr_usage.cpp
@@ -58,6 +58,7 @@ int main(){
     constexpr bool test = std::uses_allocator_v<array_2d_pmr_dynamic, std::pmr::polymorphic_allocator<int>>;
 
     array_2d_pmr_dynamic mdarray{3,3, &allocation_logger};
+    array_2d_pmr_dynamic anotherMdarray{3,3};
 
     std::pmr::vector<array_2d_pmr_dynamic> top_container{&allocation_logger};
     top_container.reserve(4);

--- a/examples/pmr_usage/pmr_usage.cpp
+++ b/examples/pmr_usage/pmr_usage.cpp
@@ -51,14 +51,13 @@ struct ChatterResource : std::pmr::memory_resource{
 
 
 int main(){
-
+    
     using array_2d_pmr_dynamic = stdex::basic_mdarray<int, stdex::extents<stdex::dynamic_extent, stdex::dynamic_extent>, stdex::layout_right, stdex::vector_container_policy<int, std::pmr::polymorphic_allocator<int>>>;
 
     ChatterResource allocation_logger;
     constexpr bool test = std::uses_allocator_v<array_2d_pmr_dynamic, std::pmr::polymorphic_allocator<int>>;
-    std::cout << sizeof(array_2d_pmr_dynamic) << std::endl;
 
-    array_2d_pmr_dynamic mdarray{std::allocator_arg, &allocation_logger, 3,3};
+    array_2d_pmr_dynamic mdarray{3,3, &allocation_logger};
 
     std::pmr::vector<array_2d_pmr_dynamic> top_container{&allocation_logger};
     top_container.reserve(4);
@@ -67,7 +66,7 @@ int main(){
     top_container.emplace_back(mdarray.mapping());
     top_container.emplace_back(mdarray.mapping(), mdarray.container_policy());
     top_container.push_back({mdarray});
-
+    
 }
 
 

--- a/include/experimental/__p1684_bits/basic_mdarray.hpp
+++ b/include/experimental/__p1684_bits/basic_mdarray.hpp
@@ -51,6 +51,7 @@
 #include <experimental/__p0009_bits/layout_right.hpp>
 #include <experimental/__p0009_bits/extents.hpp>
 #include <experimental/__p0009_bits/mdspan.hpp>
+#include <memory>
 
 namespace std {
 namespace experimental {
@@ -631,8 +632,19 @@ private:
 template <class T, size_t... Exts>
 using mdarray = basic_mdarray<T, std::experimental::extents<Exts...>>;
 
+//class basic_mdarray<
+//  ElementType, std::experimental::extents<Exts...>,
+//  LayoutPolicy, ContainerPolicy
+//>
+
+
 } // end namespace __mdarray_version_0
 } // end namespace experimental
+
+template<class ElementType, class Extents, class LayoutPolicy, class ContainerPolicy, class Allocator>
+struct uses_allocator<experimental::basic_mdarray<ElementType, Extents, LayoutPolicy, ContainerPolicy>, Allocator>
+  : uses_allocator<typename ContainerPolicy::container_type, Allocator> {};
+
 } // end namespace std
 
 #endif //MDARRAY_INCLUDE_EXPERIMENTAL_BITS_BASIC_MDARRAY_HPP_

--- a/include/experimental/__p1684_bits/container_policy_basic.hpp
+++ b/include/experimental/__p1684_bits/container_policy_basic.hpp
@@ -156,11 +156,11 @@ public:
   // TODO noexcept clause
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION static constexpr typename __base_t_::container_type),
-    create, (size_t n, Allocator& alloc), noexcept,
+    create, (size_t n, const Allocator& alloc), noexcept,
     /* requires */ (
       _MDSPAN_TRAIT(
         is_constructible,
-        typename __base_t_::container_type, size_t, typename __base_t_::element_type, Allocator&
+        typename __base_t_::container_type, size_t, typename __base_t_::element_type, const Allocator&
       )
     )
   )


### PR DESCRIPTION
Still need to make a final clean up pass (tests, clean up the dot_example, confirm the implementation works with C++17/14/11) but implemented constructors for uses-allocator construction and an example showing a `std::pmr::vector` passing it's allocator down to `mdarray`s it holds.

As for the use of raw SFINAE: I attempted to use requirements instead, but I'm pretty sure SFINAE is needed to prevent bifrucating the implementation into a partial specialization. The constructor needs to get the allocator type in a dependent context, and that can only be done during template argument deduction without causing a hard compile error in cases where the `allocator_type` member doesn't exist. Concepts and requirements are checked during overload resolution, after template argument deduction.

Of course, I could have missed something that allows a SFINAEless version to work in C++20.